### PR TITLE
[#35] 카드 컴포넌트, dashboard col layout

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -53,11 +53,6 @@ export default function Dashboard() {
           })}
         </DashboardLayout.Sidebar>
         <DashboardLayout.Content className='flex h-full w-full flex-col flex-nowrap lg:flex-row'>
-          {/**
-           * @JuhyeokC
-           * @todo
-           * 대시보드 컴포넌트 구현 필요
-           */}
           {COLUMN_TEMP_ARRAY.map((item: string, index: number) => {
             return (
               <section

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,10 +11,10 @@ const DASHBOARD_TEMP_ARRAY: string[] = Array.from(
   (_: never, index: number) => `대시보드-${index + 1}`
 )
 
-const COLUMN_TEMP_ARRAY: string[] = Array.from(
-  { length: 3 },
-  (_: never, index: number) => `COL-${index + 1}`
-)
+// const COLUMN_TEMP_ARRAY: string[] = Array.from(
+//   { length: 3 },
+//   (_: never, index: number) => `COL-${index + 1}`
+// )
 
 export default function Dashboard() {
   return (
@@ -53,21 +53,21 @@ export default function Dashboard() {
           })}
         </DashboardLayout.Sidebar>
         <DashboardLayout.Content className='flex h-full w-full flex-col flex-nowrap lg:flex-row'>
-          {COLUMN_TEMP_ARRAY.map((item: string, index: number) => {
+          {/* {COLUMN_TEMP_ARRAY.map((item: string, index: number) => {
             return (
               <section
                 key={`column-${index}`}
                 className='h-auto w-full flex-none overflow-hidden border-b border-custom-gray-200 lg:h-full lg:w-[354px] lg:border-r'
               >
-                {/* <article className='h-full w-full overflow-auto px-5 py-6'>
+                <article className='h-full w-full overflow-auto px-5 py-6'>
                   <span className='block w-full'>{item}</span>
-                </article> */}
-                <DashboardCol title='To Do' colNum={3} />
-                <DashboardCol title='On Progress' colNum={2} />
-                <DashboardCol title='Done' colNum={4} />
+                </article>
               </section>
             )
-          })}
+          })} */}
+          <DashboardCol title='To Do' />
+          <DashboardCol title='On Progress' />
+          <DashboardCol title='Done' />
           <section className='h-auto w-full flex-none overflow-hidden border-r border-custom-gray-200 lg:h-full lg:w-[354px]'>
             <div className='px-5 py-5 lg:py-16'>
               <DashboardCard type='add'>새로운 칼럼 추가하기</DashboardCard>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,8 @@
 import DashboardCard from '@/components/DashboardCard'
 import DashboardLayout from '@/layouts/DashboardLayout'
 import RootHeader from '@/layouts/RootHeader'
+import TaskCard from '@/components/TaskCard'
+import NewTaskButton from '@/components/NewTaskButton'
 
 const DASHBOARD_TEMP_ARRAY: string[] = Array.from(
   { length: 5 },
@@ -63,6 +65,8 @@ export default function Dashboard() {
                 className='h-auto w-full flex-none overflow-hidden border-b border-custom-gray-200 lg:h-full lg:w-[354px] lg:border-r'
               >
                 <article className='h-full w-full overflow-auto px-5 py-6'>
+                  <NewTaskButton />
+                  <TaskCard>새로운 일정</TaskCard>
                   <span className='block w-full'>{item}</span>
                 </article>
               </section>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import DashboardCard from '@/components/DashboardCard'
 import DashboardLayout from '@/layouts/DashboardLayout'
 import RootHeader from '@/layouts/RootHeader'
 import TaskCard from '@/components/TaskCard'
-import NewTaskButton from '@/components/NewTaskButton'
+import DashboardCol from '@/layouts/DashboardCol'
 
 const DASHBOARD_TEMP_ARRAY: string[] = Array.from(
   { length: 5 },
@@ -59,11 +59,12 @@ export default function Dashboard() {
                 key={`column-${index}`}
                 className='h-auto w-full flex-none overflow-hidden border-b border-custom-gray-200 lg:h-full lg:w-[354px] lg:border-r'
               >
-                <article className='h-full w-full overflow-auto px-5 py-6'>
-                  <NewTaskButton />
-                  <TaskCard>새로운 일정</TaskCard>
+                {/* <article className='h-full w-full overflow-auto px-5 py-6'>
                   <span className='block w-full'>{item}</span>
-                </article>
+                </article> */}
+                <DashboardCol title='To Do' colNum={3} />
+                <DashboardCol title='On Progress' colNum={2} />
+                <DashboardCol title='Done' colNum={4} />
               </section>
             )
           })}

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,0 +1,14 @@
+import cn from 'classnames'
+import { ReactNode } from 'react'
+
+interface ChipProps {
+  children: ReactNode
+}
+
+export default function Chip({ children }: ChipProps) {
+  return (
+    <div className='flex h-7 w-14 items-center justify-center gap-1.5 rounded-md bg-[#F9EEE3] px-6 py-4 text-sm font-normal'>
+      <span>{children}</span>
+    </div>
+  )
+}

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -5,9 +5,54 @@ interface ChipProps {
   children: ReactNode
 }
 
+// tailwind.config.ts 파일의 tag 색상 값을 Chip 컴포넌트 내에 정의
+const tagColors = {
+  orange: {
+    100: 'bg-[#F9EEE3]',
+    200: 'bg-[#D58D49]',
+  },
+  green: {
+    100: 'bg-[#E7F7DB]',
+    200: 'bg-[#86D549]',
+  },
+  pink: {
+    100: 'bg-[#F7DBF0]',
+    200: 'bg-[#D549B6]',
+  },
+  blue: {
+    100: 'bg-[#DBE6F7]',
+    200: 'bg-[#4981D5]',
+  },
+}
+
+function getRandomColor() {
+  const colorCategories = Object.keys(tagColors)
+  const randomCategory =
+    colorCategories[Math.floor(Math.random() * colorCategories.length)]
+  const colors = tagColors[randomCategory]
+  const colorShades = Object.keys(colors)
+  const randomShade =
+    colorShades[Math.floor(Math.random() * colorShades.length)]
+  return {
+    bgColor: colors[randomShade],
+    textColor:
+      randomCategory === 'orange' || randomCategory === 'pink'
+        ? 'text-black'
+        : 'text-white',
+  }
+}
+
 export default function Chip({ children }: ChipProps) {
+  const { bgColor, textColor } = getRandomColor()
+
   return (
-    <div className='flex h-7 w-14 items-center justify-center gap-1.5 rounded-md bg-[#F9EEE3] px-6 py-4 text-sm font-normal'>
+    <div
+      className={cn(
+        'mr-[6px] flex rounded-md px-[6px] py-[2px] text-[14px] font-normal',
+        bgColor,
+        textColor
+      )}
+    >
       <span>{children}</span>
     </div>
   )

--- a/src/components/NewTaskButton.tsx
+++ b/src/components/NewTaskButton.tsx
@@ -1,0 +1,11 @@
+import cn from 'classnames'
+import { ReactNode } from 'react'
+import AddButton from '../../public/icons/add-box2.svg'
+
+export default function NewTaskButton() {
+  return (
+    <div className='mb-4 flex w-80 justify-center rounded-md border-[1px] border-solid border-custom-gray-300 bg-white py-[9px]'>
+      <AddButton className='h-[22px] w-[22px]' />
+    </div>
+  )
+}

--- a/src/components/NewTaskButton.tsx
+++ b/src/components/NewTaskButton.tsx
@@ -2,10 +2,19 @@ import cn from 'classnames'
 import { ReactNode } from 'react'
 import AddButton from '../../public/icons/add-box2.svg'
 
-export default function NewTaskButton() {
+interface NewTaskButtonProps {
+  onClick?: () => void
+}
+
+export default function NewTaskButton({ onClick }: NewTaskButtonProps) {
   return (
-    <div className='mb-4 flex w-80 justify-center rounded-md border-[1px] border-solid border-custom-gray-300 bg-white py-[9px]'>
+    <button
+      onClick={onClick}
+      className='mb-4 flex w-80 justify-center rounded-md border-[1px] border-solid border-custom-gray-300 bg-white py-[9px] hover:bg-custom-gray-100'
+    >
       <AddButton className='h-[22px] w-[22px]' />
-    </div>
+    </button>
   )
 }
+
+// TODO: onClick시, 할일 생성 모달이 열려야 합니다.

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,0 +1,31 @@
+import cn from 'classnames'
+import { ReactNode } from 'react'
+import Chip from '@/components/Chip'
+import Calendar from '../../public/icons/calendar.svg'
+import Exam from '../../public/images/example-01.svg'
+
+interface CardProps {
+  children: ReactNode
+}
+
+export default function TaskCard({ children }: CardProps) {
+  return (
+    <div className='w-80 rounded-md border-[1px] border-solid border-custom-gray-300 bg-white px-5 py-4'>
+      <div className='w-[274px] pb-4'>
+        <Exam className='size-full' />
+      </div>
+      <div className='pb-2.5 text-base font-medium'>{children}</div>
+      <div className='flex pb-2'>
+        <Chip>2</Chip>
+        <Chip>태그1</Chip>
+      </div>
+      <div className='flex'>
+        <Calendar
+          className='mr-[6px] h-[15px] w-[15px] text-custom-gray-500'
+          viewBox='0 0 18 18'
+        />
+        <span className='text-[12px] text-custom-gray-500'>2022.12.31</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -10,7 +10,7 @@ interface CardProps {
 
 export default function Card({ children, imageSrc }: CardProps) {
   return (
-    <div className='w-80 rounded-md border-[1px] border-solid border-custom-gray-300 bg-white px-5 py-4'>
+    <div className='mb-4 w-80 rounded-md border-[1px] border-solid border-custom-gray-300 bg-white px-5 py-4'>
       {imageSrc && (
         <div className='w-[274px] pb-4'>
           <img src={imageSrc} alt='TaskCard 이미지' className='size-full' />

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -8,23 +8,28 @@ interface CardProps {
   children: ReactNode
 }
 
-export default function TaskCard({ children }: CardProps) {
+export default function Card({ children }: CardProps) {
   return (
     <div className='w-80 rounded-md border-[1px] border-solid border-custom-gray-300 bg-white px-5 py-4'>
       <div className='w-[274px] pb-4'>
         <Exam className='size-full' />
       </div>
       <div className='pb-2.5 text-base font-medium'>{children}</div>
-      <div className='flex pb-2'>
+      <div className='flex pb-3'>
         <Chip>2</Chip>
         <Chip>태그1</Chip>
       </div>
       <div className='flex'>
-        <Calendar
-          className='mr-[6px] h-[15px] w-[15px] text-custom-gray-500'
-          viewBox='0 0 18 18'
-        />
-        <span className='text-[12px] text-custom-gray-500'>2022.12.31</span>
+        <div className='flex'>
+          <Calendar
+            className='mr-[6px] h-[15px] w-[15px] text-custom-gray-500'
+            viewBox='0 0 18 18'
+          />
+          <span className='text-[12px] text-custom-gray-500'>2022.12.31</span>
+        </div>
+        <span className='text-4 ml-auto mt-[-3px] flex h-6 w-6 justify-center rounded-[50%] bg-custom-green text-white'>
+          B
+        </span>
       </div>
     </div>
   )

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -2,18 +2,20 @@ import cn from 'classnames'
 import { ReactNode } from 'react'
 import Chip from '@/components/Chip'
 import Calendar from '../../public/icons/calendar.svg'
-import Exam from '../../public/images/example-01.svg'
 
 interface CardProps {
   children: ReactNode
+  imageSrc?: string
 }
 
-export default function Card({ children }: CardProps) {
+export default function Card({ children, imageSrc }: CardProps) {
   return (
     <div className='w-80 rounded-md border-[1px] border-solid border-custom-gray-300 bg-white px-5 py-4'>
-      <div className='w-[274px] pb-4'>
-        <Exam className='size-full' />
-      </div>
+      {imageSrc && (
+        <div className='w-[274px] pb-4'>
+          <img src={imageSrc} alt='TaskCard 이미지' className='size-full' />
+        </div>
+      )}
       <div className='pb-2.5 text-base font-medium'>{children}</div>
       <div className='flex pb-3'>
         <Chip>2</Chip>

--- a/src/layouts/DashboardCol.tsx
+++ b/src/layouts/DashboardCol.tsx
@@ -1,0 +1,32 @@
+import cn from 'classnames'
+import Bullet from '../../public/icons/bullet.svg'
+import Setting from '../../public/icons/settings.svg'
+import NewTaskButton from '@/components/NewTaskButton'
+import TaskCard from '../components/TaskCard'
+
+interface DashboardColProps {
+  title: string
+  colNum: number
+}
+
+export default function DashboardCol({ title, colNum }: DashboardColProps) {
+  return (
+    <div className='h-auto w-full flex-none overflow-hidden border-b border-custom-gray-200 lg:h-full lg:w-[354px] lg:border-r'>
+      <div className='h-full w-full overflow-auto px-5'>
+        <div className='mb-[25px] mt-[22px] flex'>
+          <div className='flex items-center'>
+            <Bullet className='text-2 mr-2 text-custom-violet' />
+            <div className='mr-3 text-lg font-bold'>{title}</div>
+            <span className='flex h-5 w-5 items-center justify-center rounded bg-custom-gray-200 text-[12px]'>
+              {colNum}
+            </span>
+          </div>
+          <button className='ml-auto'>
+            <Setting className='h-[19px] w-[19px] text-custom-gray-500' />
+          </button>
+        </div>
+        <NewTaskButton />
+      </div>
+    </div>
+  )
+}

--- a/src/layouts/DashboardCol.tsx
+++ b/src/layouts/DashboardCol.tsx
@@ -1,3 +1,4 @@
+import { useState, ReactNode } from 'react'
 import cn from 'classnames'
 import Bullet from '../../public/icons/bullet.svg'
 import Setting from '../../public/icons/settings.svg'
@@ -6,10 +7,16 @@ import TaskCard from '../components/TaskCard'
 
 interface DashboardColProps {
   title: string
-  colNum: number
+  colNum?: number
 }
 
-export default function DashboardCol({ title, colNum }: DashboardColProps) {
+export default function DashboardCol({ title }: DashboardColProps) {
+  const [taskCards, setTaskCards] = useState<ReactNode[]>([])
+
+  const handleAddTask = () => {
+    setTaskCards([...taskCards, <TaskCard key={taskCards.length} />])
+  }
+
   return (
     <div className='h-auto w-full flex-none overflow-hidden border-b border-custom-gray-200 lg:h-full lg:w-[354px] lg:border-r'>
       <div className='h-full w-full overflow-auto px-5'>
@@ -18,14 +25,15 @@ export default function DashboardCol({ title, colNum }: DashboardColProps) {
             <Bullet className='text-2 mr-2 text-custom-violet' />
             <div className='mr-3 text-lg font-bold'>{title}</div>
             <span className='flex h-5 w-5 items-center justify-center rounded bg-custom-gray-200 text-[12px]'>
-              {colNum}
+              {taskCards.length}
             </span>
           </div>
           <button className='ml-auto'>
             <Setting className='h-[19px] w-[19px] text-custom-gray-500' />
           </button>
         </div>
-        <NewTaskButton />
+        <NewTaskButton onClick={handleAddTask} />
+        <div>{taskCards}</div>
       </div>
     </div>
   )

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -3,6 +3,8 @@ import cn from 'classnames'
 import styles from './ResponsiveLayout.module.css'
 import { HEADER_HEIGHT } from './RootHeader'
 import RootSidebar from './RootSidebar'
+import DashboardCol from './DashboardCol'
+import TaskCard from '../components/TaskCard'
 
 interface ClassNameProp {
   className?: string


### PR DESCRIPTION
## 어떤 기능인가요?

> dashboard/[id] 페이지에서 쓰이는 Column 컴포넌트입니다.

## 작업 상세 내용
### 1) 기본 대시보드 레이아웃입니다
![스크린샷 2024-08-06 오전 6 32 44](https://github.com/user-attachments/assets/5db435a4-602d-4e2d-91aa-555312526966)

### 2) 카드 개수만큼 Col Title 뱃지에 숫자가 표시됩니다.
### [이미지 없을 때]
![스크린샷 2024-08-06 오전 6 33 15](https://github.com/user-attachments/assets/77375a24-cdf9-4985-bb40-0418d7defaf5)

### [이미지 있을 때]
![스크린샷 2024-08-06 오전 6 35 17](https://github.com/user-attachments/assets/6b2f05fa-0434-469e-a455-8cbcb33b120f)

- [x] 칼럽 헤더 (컬러 칩 / 태스크 카운트 / 칼럼 세팅 버튼)
- [x] 태스크 추가 버튼
- [x] 태스크 리스트
 
## 팀원들에게 알리고 싶다
- 버튼 테스트 & 뱃지 숫자 테스트로 '+' 버튼을 누르면 임의로 카드가 추가되는 기능을 잠시 구현했습니다
- 원래는 '+' 버튼을 누르면 '할일생성' 모달이 열립니다.
- '할일 생성' 모달의 값으로 카드의 값이 채워집니다.
- 태그Chip 랜덤 색상 기능은 수정할 예정입니다.