### PR TITLE
[#100] 리다이렉트

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import {useParams} from 'next/navigation'
-import {PropsWithChildren, useEffect} from 'react'
+import { useParams } from 'next/navigation'
+import { PropsWithChildren, useEffect } from 'react'
 
+import useRedirect from '@/hooks/useRedirect'
 import DashboardLayout from '@/layouts/DashboardLayout'
 import useDashboardStore from '@/store/useDashboardStore'
 
@@ -12,6 +13,8 @@ import useDashboardStore from '@/store/useDashboardStore'
  * 주스탠드에 저장된 대시보드 목록에서 dashboardid 로 title 가져올 수 잇을 듯
  */
 export default function UserDashboardLayout({ children }: PropsWithChildren) {
+  useRedirect({ requireAuth: true })
+
   const { id } = useParams()
   const { dashboards, dashboard, setDashboard } = useDashboardStore()
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,11 @@
+'use client'
+
 import LoginForm from '@/app/login/components/LoginForm'
+import useRedirect from '@/hooks/useRedirect'
 import AuthPageLayout from '@/layouts/AuthPageLayout'
 
 export default function LoginPage() {
+  useRedirect({ requireAuth: false })
   return (
     <AuthPageLayout page='login'>
       <LoginForm />

--- a/src/app/mydashboard/page.tsx
+++ b/src/app/mydashboard/page.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import DashboardCard from '@/components/DashboardCard'
 import Pagination from '@/components/Pagination'
 import usePagination from '@/hooks/usePagination'
+import useRedirect from '@/hooks/useRedirect'
 import useDashboardStore from '@/store/useDashboardStore'
 import { Dashboards } from '@/types/types'
 
@@ -15,6 +16,8 @@ type PaginationAction = 'prev' | 'next'
 const ITEM_PER_PAGE = 5
 
 export default function MyDashboard() {
+  useRedirect({ requireAuth: true })
+
   const { dashboards } = useDashboardStore()
   const [list, setList] = useState<Dashboards>(null)
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,11 +1,14 @@
 'use client'
 import CaretLeft from '/public/icons/caret-left.svg'
 import useGoBack from '@/hooks/useGoBack'
+import useRedirect from '@/hooks/useRedirect'
 
 import PasswordEditForm from './components/PasswordEditForm'
 import ProfileEditForm from './components/ProfileEditForm'
 
 export default function MyPagePage() {
+  useRedirect({ requireAuth: true })
+
   const handleGoBack = useGoBack()
   return (
     <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import LandingFooter from '@/components/LandingFooter'
 import useAutotyping from '@/hooks/useAutotyping'
 import useMediaQuery from '@/hooks/useMediaQuery'
-import useRedirect, { type UseRedirect } from '@/hooks/useRedirect'
+import useRedirect from '@/hooks/useRedirect'
 import RootHeader from '@/layouts/RootHeader'
 
 import { Providers } from './providers'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,11 +2,11 @@
 import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useState } from 'react'
 
 import LandingFooter from '@/components/LandingFooter'
 import useAutotyping from '@/hooks/useAutotyping'
 import useMediaQuery from '@/hooks/useMediaQuery'
+import useRedirect, { type UseRedirect } from '@/hooks/useRedirect'
 import RootHeader from '@/layouts/RootHeader'
 
 import { Providers } from './providers'
@@ -18,6 +18,8 @@ type TypeTextWidth = {
   desktop: number
 }
 export default function Home() {
+  useRedirect({ requireAuth: false })
+
   const { currentText } = useAutotyping('Taskify')
   const mode: Mode = useMediaQuery()
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,7 +1,11 @@
+'use client'
+
 import SignupForm from '@/app/signup/components/SignupForm'
+import useRedirect from '@/hooks/useRedirect'
 import AuthPageLayout from '@/layouts/AuthPageLayout'
 
 export default function SignupPage() {
+  useRedirect({ requireAuth: false })
   return (
     <AuthPageLayout page='signup'>
       <SignupForm />

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -15,7 +15,6 @@ export default function UserProfile() {
   const { user, setUser } = useUserStore()
 
   const getUser = async () => {
-    if (!sessionStorage?.accessToken) return router.push('/login')
     try {
       const response = await api.get('users/me')
       setUser(response.data)
@@ -34,7 +33,8 @@ export default function UserProfile() {
 
   useEffect(() => {
     if (user === null) getUser()
-  })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const classNames = cn(
     'relative',

--- a/src/hooks/useRedirect.ts
+++ b/src/hooks/useRedirect.ts
@@ -1,0 +1,21 @@
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+interface UseRedirect {
+  requireAuth: boolean
+}
+
+const useRedirect = ({ requireAuth }: UseRedirect) => {
+  const router = useRouter()
+  useEffect(() => {
+    const token = sessionStorage.getItem('accessToken')
+
+    if (token && !requireAuth) {
+      router.push('/mydashboard')
+    } else if (!token && requireAuth) {
+      router.push('/')
+    }
+  }, [router, requireAuth])
+}
+
+export default useRedirect


### PR DESCRIPTION
resolved: #100 

로그인을 요구하는 페이지 (대시보드, 마이대시보드, 마이페이지) 에 토큰 없이 접근하면 -> 랜딩 페이지로
반대로 토큰이 있는데 로그인, 회원가입, 랜딩 페이지 접근 시에는 -> my 대시보드 페이지로

요구사항에는 dashboard/[첫 id] 로 보내라고 되어 있는데, 대시보드 리스트 관련 로직 추가하고 수정하겠습니다
그리고 찾아봤는데, 넥스트에서 리다이렉트는 middleware.ts 쓰는 멋있는 방법이 있으나
우리는 오롯이 클라이언트 사이드에서 리다이렉트를 제어할 수 밖에 없기 때문에 훅을 만들어서 접근했습니다