### PR TITLE
Feat/#206 서버사이드 로그인 기능 개발

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -13,7 +13,7 @@ import useDashboardStore from '@/store/useDashboardStore'
  * 주스탠드에 저장된 대시보드 목록에서 dashboardid 로 title 가져올 수 잇을 듯
  */
 export default function UserDashboardLayout({ children }: PropsWithChildren) {
-  useRedirect({ requireAuth: true })
+  // useRedirect({ requireAuth: true })
 
   const { id } = useParams()
   const { dashboards, dashboard, setDashboard } = useDashboardStore()

--- a/src/app/login/components/LoginForm.tsx
+++ b/src/app/login/components/LoginForm.tsx
@@ -40,26 +40,12 @@ export default function LoginForm() {
 
   const onSubmit = async (data: LoginFormValue) => {
     // 로그인 액션 실행
-    console.log(data)
-    loginAction(data)
-    // try {
-    //   const response = await api.post('auth/login', data)
-    //   const { accessToken, user } = response.data
-    //   sessionStorage.setItem('accessToken', accessToken)
-    //   sessionStorage.setItem('user', JSON.stringify(user))
-    //   const dashboards = await getDashboardList()
-    //   setDashboards(dashboards)
-    //   router.push('/mydashboard')
-    // } catch (error) {
-    //   let loginErrorMessage = ''
-    //   if (axios.isAxiosError(error)) {
-    //     loginErrorMessage = error.response?.data.message
-    //   } else {
-    //     loginErrorMessage =
-    //       '서버에 문제가 있는거 같아요. 잠시 후에 다시 시도해보시겠어요?'
-    //   }
-    //   openModal(<ConfirmModalContent message={loginErrorMessage} />)
-    // }
+    const errMsg = await loginAction(data)
+
+    // 에러 메시지 팝업
+    if (errMsg) {
+      openModal(<ConfirmModalContent message={errMsg} />)
+    }
   }
 
   const isDisabled = !!(errors.email || errors.password || isLoading)

--- a/src/app/login/components/LoginForm.tsx
+++ b/src/app/login/components/LoginForm.tsx
@@ -13,6 +13,8 @@ import { getDashboardList } from '@/lib/dashboardsApi'
 import useDashboardStore from '@/store/useDashboardStore'
 import useModalStore from '@/store/useModalStore'
 
+import loginAction from '../loginAction'
+
 export interface LoginFormValue {
   email: string
   password: string
@@ -29,6 +31,7 @@ export default function LoginForm() {
   } = useForm<LoginFormValue>()
 
   const router = useRouter()
+
   const { openModal } = useModalStore()
   const { setDashboards } = useDashboardStore()
 
@@ -36,24 +39,27 @@ export default function LoginForm() {
   const passwordType = pwdVisible ? 'text' : 'password'
 
   const onSubmit = async (data: LoginFormValue) => {
-    try {
-      const response = await api.post('auth/login', data)
-      const { accessToken, user } = response.data
-      sessionStorage.setItem('accessToken', accessToken)
-      sessionStorage.setItem('user', JSON.stringify(user))
-      const dashboards = await getDashboardList()
-      setDashboards(dashboards)
-      router.push('/mydashboard')
-    } catch (error) {
-      let loginErrorMessage = ''
-      if (axios.isAxiosError(error)) {
-        loginErrorMessage = error.response?.data.message
-      } else {
-        loginErrorMessage =
-          '서버에 문제가 있는거 같아요. 잠시 후에 다시 시도해보시겠어요?'
-      }
-      openModal(<ConfirmModalContent message={loginErrorMessage} />)
-    }
+    // 로그인 액션 실행
+    console.log(data)
+    loginAction(data)
+    // try {
+    //   const response = await api.post('auth/login', data)
+    //   const { accessToken, user } = response.data
+    //   sessionStorage.setItem('accessToken', accessToken)
+    //   sessionStorage.setItem('user', JSON.stringify(user))
+    //   const dashboards = await getDashboardList()
+    //   setDashboards(dashboards)
+    //   router.push('/mydashboard')
+    // } catch (error) {
+    //   let loginErrorMessage = ''
+    //   if (axios.isAxiosError(error)) {
+    //     loginErrorMessage = error.response?.data.message
+    //   } else {
+    //     loginErrorMessage =
+    //       '서버에 문제가 있는거 같아요. 잠시 후에 다시 시도해보시겠어요?'
+    //   }
+    //   openModal(<ConfirmModalContent message={loginErrorMessage} />)
+    // }
   }
 
   const isDisabled = !!(errors.email || errors.password || isLoading)

--- a/src/app/login/loginAction.tsx
+++ b/src/app/login/loginAction.tsx
@@ -1,5 +1,4 @@
 'use server'
-
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
@@ -10,33 +9,19 @@ import { LoginFormValue } from './components/LoginForm'
 export default async function loginAction(data: LoginFormValue) {
   // 백엔드 요청
   try {
-    const response = await fetch(
-      'https://sp-taskify-api.vercel.app/7-2/auth/login',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
-      }
-    )
-
-    const responsedData = await response.json()
-    if (responsedData.message) {
-      throw new Error(responsedData.message)
-    }
-    const { accessToken, user } = responsedData
+    const response = await api.post('/auth/login', data, {})
+    const { accessToken, user } = response.data
 
     // 가져온 json token 쿠키 설정 하기
     cookies().set('Authorization', accessToken, {
       secure: true,
       httpOnly: true,
-      expires: Date.now() + 24 * 60 * 60 * 1000 * 3,
+      expires: new Date(Date.now() + 24 * 60 * 60 * 1000 * 3),
       path: '/',
       sameSite: 'strict',
     })
   } catch (error: any) {
-    return error.message
+    return error.response?.data?.message || error.message
   }
 
   // 로그인 여부에 따라 redirect

--- a/src/app/login/loginAction.tsx
+++ b/src/app/login/loginAction.tsx
@@ -2,7 +2,7 @@
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
-import api from '@/lib/axiosInstance'
+import api from '@/lib/axiosServer'
 
 import { LoginFormValue } from './components/LoginForm'
 
@@ -15,9 +15,9 @@ export default async function loginAction(data: LoginFormValue) {
     // 가져온 json token 쿠키 설정 하기
     cookies().set('Authorization', accessToken, {
       secure: true,
-      httpOnly: true,
+      // httpOnly: true,
       expires: new Date(Date.now() + 24 * 60 * 60 * 1000 * 3),
-      path: '/',
+      // path: '/',
       sameSite: 'strict',
     })
   } catch (error: any) {

--- a/src/app/login/loginAction.tsx
+++ b/src/app/login/loginAction.tsx
@@ -1,0 +1,17 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import api from '@/lib/axiosInstance'
+
+import { LoginFormValue } from './components/LoginForm'
+
+export default async function loginAction(data: LoginFormValue) {
+  // 폼에서 데이터 가져오기 = data
+  // 백엔드 요청
+  // 가져온 json token 쿠키 설정 하기
+  // 로그인 여부에 따라 redirect
+
+  return { message: 'test' }
+}

--- a/src/app/login/loginAction.tsx
+++ b/src/app/login/loginAction.tsx
@@ -8,10 +8,37 @@ import api from '@/lib/axiosInstance'
 import { LoginFormValue } from './components/LoginForm'
 
 export default async function loginAction(data: LoginFormValue) {
-  // 폼에서 데이터 가져오기 = data
   // 백엔드 요청
-  // 가져온 json token 쿠키 설정 하기
-  // 로그인 여부에 따라 redirect
+  try {
+    const response = await fetch(
+      'https://sp-taskify-api.vercel.app/7-2/auth/login',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      }
+    )
 
-  return { message: 'test' }
+    const responsedData = await response.json()
+    if (responsedData.message) {
+      throw new Error(responsedData.message)
+    }
+    const { accessToken, user } = responsedData
+
+    // 가져온 json token 쿠키 설정 하기
+    cookies().set('Authorization', accessToken, {
+      secure: true,
+      httpOnly: true,
+      expires: Date.now() + 24 * 60 * 60 * 1000 * 3,
+      path: '/',
+      sameSite: 'strict',
+    })
+  } catch (error: any) {
+    return error.message
+  }
+
+  // 로그인 여부에 따라 redirect
+  redirect('/mydashboard')
 }

--- a/src/app/mydashboard/page.tsx
+++ b/src/app/mydashboard/page.tsx
@@ -18,7 +18,7 @@ type PaginationAction = 'prev' | 'next'
 const ITEM_PER_PAGE = 5
 
 export default function MyDashboard() {
-  useRedirect({ requireAuth: true })
+  // useRedirect({ requireAuth: true })
 
   const { openModal } = useModalStore()
   const { dashboards } = useDashboardStore()

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -7,7 +7,7 @@ import PasswordEditForm from './components/PasswordEditForm'
 import ProfileEditForm from './components/ProfileEditForm'
 
 export default function MyPagePage() {
-  useRedirect({ requireAuth: true })
+  // useRedirect({ requireAuth: true })
 
   const handleGoBack = useGoBack()
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import useRedirect from '@/hooks/useRedirect'
 import { Providers } from './providers'
 
 export default function Home() {
-  useRedirect({ requireAuth: false })
+  // useRedirect({ requireAuth: false })
 
   return (
     <>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -5,7 +5,7 @@ import useRedirect from '@/hooks/useRedirect'
 import AuthPageLayout from '@/layouts/AuthPageLayout'
 
 export default function SignupPage() {
-  useRedirect({ requireAuth: false })
+  // useRedirect({ requireAuth: false })
   return (
     <AuthPageLayout page='signup'>
       <SignupForm />

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -18,6 +18,7 @@ export default function UserProfile() {
     try {
       const response = await api.get('users/me')
       setUser(response.data)
+      sessionStorage.setItem('user', response.data)
     } catch (error) {
       throw error
     }
@@ -31,6 +32,8 @@ export default function UserProfile() {
     router.push('/login')
     setUser(null)
     sessionStorage.clear()
+
+    document.cookie = `Authorization=; Max-Age=-99999999;`
   }
 
   useEffect(() => {

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -15,17 +15,17 @@ export const setAccessToken = (token: string) => {
   accessToken = token
 }
 
-api.interceptors.request.use(
-  config => {
-    const token = sessionStorage.getItem('accessToken')
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-    }
-    return config
-  },
-  error => {
-    return Promise.reject(error)
-  }
-)
+// api.interceptors.request.use(
+//   config => {
+//     const token = sessionStorage.getItem('accessToken')
+//     if (token) {
+//       config.headers.Authorization = `Bearer ${token}`
+//     }
+//     return config
+//   },
+//   error => {
+//     return Promise.reject(error)
+//   }
+// )
 
 export default api

--- a/src/lib/axiosServer.ts
+++ b/src/lib/axiosServer.ts
@@ -1,26 +1,21 @@
+'use server'
+
 import axios from 'axios'
+import { cookies } from 'next/headers'
 
 const api = axios.create({
   baseURL: 'https://sp-taskify-api.vercel.app/7-2',
   headers: {
     'Content-Type': 'application/json',
   },
-  // withCredentials: true,
+  withCredentials: true,
 })
 
 api.interceptors.request.use(
   config => {
-    function getCookie(name: string) {
-      const value = `; ${document.cookie}`
-      const parts = value.split(`; ${name}=`)
+    console.log('interceptor')
+    const token = cookies().get('Authorization')
 
-      if (parts) {
-        return parts[1].split(';').shift()
-      }
-    }
-
-    const token = getCookie('Authorization')
-    console.log(token)
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,15 @@
+import { cookies } from 'next/headers'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export async function middleware(request: NextRequest) {
+  // 쿠키 확인
+  const cookie = cookies().get('Authorization')
+  if (!cookie) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+}
+
+export const config = {
+  matcher: ['/mydashboard/:path*', '/dashboard/:path*', '/mypage/:path*'],
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,8 +8,12 @@ export async function middleware(request: NextRequest) {
   if (!cookie) {
     return NextResponse.redirect(new URL('/login', request.url))
   }
+
+  if (cookie && request.nextUrl.pathname === '/') {
+    return NextResponse.redirect(new URL('/mydashboard', request.url))
+  }
 }
 
 export const config = {
-  matcher: ['/mydashboard/:path*', '/dashboard/:path*', '/mypage/:path*'],
+  matcher: ['/', '/mydashboard/:path*', '/dashboard/:path*', '/mypage/:path*'],
 }


### PR DESCRIPTION
resolved: #206 

로그인 수정했습니다.

- axios client/server두 가지로 나눔
- login actions(react server action)으로 로그인 처리 -> 서버 axios instance
- 클라이언트에서 호출하는 api 대응 -> 클라이언트 axios instance
- 미들웨어 추가
- cookie로 토큰 데이터 관리

요 정도 수정한 것 같습니다.

제가 수정한 기존 소스는 
기존에 로그인 하면서 대시보드 데이터와 유저 데이터도 같이 세션 스토리지에 저장하고 있었는데, 
유저 데이터는 세션 스토리지에 저장하는 걸 getUser하는 부분으로 옮김
(대시보드 데이터는 따로 처리하지 않았는데 잘 나오네요)
기존 useRedirect 주석 처리

꼭 머지하려는 건 아니고 이런 방식으로 구현하는 방법 연구했다고 생각해주심 될 거 같습니다.
참고 : https://www.youtube.com/watch?v=INwOeQ0RagY

제가 어렵게 생각했던 부분이 
1. 쿠키 set하는 방법
2. axios interceptor 처리
3. server action 작성 및 사용

이 세 가지 정도로 정리할 수 있을 것 같은데,
axios 클라이언트를 분리해야한다는 생각을 못해서 axios 인터셉터가 여기저기 꼬이다보니까
이것들을 어떻게 처리해야할지 고민이 많았습니다.
특히 2번이 이해가 잘 안 가다 보니까 전체적인 그림을 어떻게 그려야할 지 몰라서 많이 헤맸는데, 분리가 답이었네요

httpOnly옵션을 써서 서버사이드에서만 적용할 수 있도록 작성해볼까 했는데, 이미 클라이언트에서 api호출을 다 하고 있어 전체적인 구조 변경이 불가피 하더라구요
그래서 일단 두 가지로 이원화해봤습니다.